### PR TITLE
Add substrate guideline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "conventionalCommits.scopes": [
-        "tools-extensions",
-        "testing"
-    ]
-}

--- a/docs/development/prerequisite.md
+++ b/docs/development/prerequisite.md
@@ -27,6 +27,8 @@ Any level of familiarity with either of the subjects will be useful but is _not_
 
 To start developing on Ajuna Network, we recommend reading through our suggestions below.
 
+Also see [Tools and Extensions](tools-and-extensions.md) for more recommendations.
+
 ### Build Dependencies
 
 The main binary required to build our blockchain project is [OpenSSL][openssl].

--- a/docs/development/rust.md
+++ b/docs/development/rust.md
@@ -4,6 +4,8 @@ title: Rust Development
 permalink: /guides/development/rust
 ---
 
+[api-guidelines-discussion-29]: https://github.com/rust-lang/api-guidelines/discussions/29
+[crates-io]: https://crates.io/
 [design-patterns]: https://rust-unofficial.github.io/patterns/patterns/index.html
 [destructuring]: https://doc.rust-lang.org/rust-by-example/flow_control/match/destructuring.html
 [if-let]: https://doc.rust-lang.org/rust-by-example/flow_control/if_let.html
@@ -11,6 +13,30 @@ permalink: /guides/development/rust
 [software-design-principles]: https://en.wikipedia.org/wiki/List_of_software_development_philosophies#Rules_of_thumb,_laws,_guidelines_and_principles
 
 # Rust Development
+
+### Crate Naming Convention
+
+There isn't a standard naming convention for crates [see this discussion][api-guidelines-discussion-29] however we recommend names in hyphen-delimited kebab-case with prefix `ajuna-*`, where appropriate.
+
+Also consider using:
+
+- nesting or hierarchy as a way to group packages together
+- suffixes to differentiate between
+
+For example,
+
+```
+ajuna-dot4-engine
+ajuna-dot4-client
+ajuna-dot4-deployment
+```
+
+When publishing to [crates.io][crates-io], we want to double-check on the names as they are immutable.
+
+### Repo Naming Convention
+
+The only standard we enforce in naming Rust-based repositories is using kebab-case.
+Most names should be acceptable as long as the names reflect their intended purposes.
 
 ### Design Principles
 

--- a/docs/development/substrate.md
+++ b/docs/development/substrate.md
@@ -1,0 +1,98 @@
+---
+layout: default
+title: Substrate Development
+permalink: /guides/development/substrate
+---
+
+[crates-io]: https://crates.io/
+[ipfs]: https://ipfs.io/
+[parachain-devops-best-practices]: https://gist.github.com/lovelaced/cddc1c7234b883ee37e71cf4a1d63cac
+[rust-docs-collections-performances]: https://doc.rust-lang.org/std/collections/index.html#performance
+[rust-rocksdb]: https://github.com/rust-rocksdb/rust-rocksdb
+[substrate-docs]: https://docs.substrate.io/
+[substrate-docs-getting-started]: https://docs.substrate.io/v3/getting-started/overview/
+[substrate-docs-how-to-guides]: https://docs.substrate.io/how-to-guides/v3/
+[substrate-docs-tutorials]: https://docs.substrate.io/tutorials/v3/
+[substrate-docs-rustdocs]: https://docs.substrate.io/rustdocs/
+[substrate-docs-storage]: https://docs.substrate.io/v3/runtime/storage/
+[substrate-docs-benchmarking]: https://docs.substrate.io/v3/runtime/benchmarking/#best-practices-and-common-patterns
+[substrate-monthly-releases]: https://github.com/paritytech/substrate/releases?q=monthly-&expanded=true
+
+# Substrate Development
+
+The best resources in Substrate development are the official docs:
+
+- [Substrate Developer Hub][substrate-docs]
+  - [Docs][substrate-docs-getting-started] - concepts and high-level overview of ideas
+  - [How-to Guides][substrate-docs-how-to-guides] - more in-depth, hands-on guide and recipes on developing in Substrate
+  - [Tutorials][substrate-docs-tutorials] - code exercises and walkthrough on various use cases of Substrate
+- [Substrate Rust Docs][substrate-docs-rustdocs]
+
+### Crate Naming Convention
+
+Follow the convention mentioned in [Rust Development](rust.md#crate-naming-convention) with exception for runtime modules (or pallets).
+
+For pallets, prefixing with `ajuna-pallet-*` is appropriate.
+
+### Managing Substrate Dependencies
+
+Recommended is to peg our upstream dependencies at [monthly snapshot releases][substrate-monthly-releases] with a dedicated time slot each month for upgrading.
+
+#### Versioned, monthly or latest releases - which one to use
+
+Versioned released are infrequent in Substrate which often leads to a simple upgrade task requiring lots of effort.
+Other options include:
+
+- pointing directly to the latest `master` branch, which means
+  - our maintenance effort is increased substantially due to breaking changes
+  - our codebase has the latest and greatest changes
+- pointing to a specific commit on `master` branch, which means
+  - our maintenance effort can be managed
+  - our codebase has the latest and greatest changes up until the commit
+  - it's difficult to understand what changes are included up until that particular commit
+
+A nice trade-off between maintainability vs. latest tech is provided via [monthly snapshot releases][substrate-monthly-releases], where we can dedicate a time slot for upgrading every month.
+A changelog for each monthly release is also provided to help us understand its associated changes.
+
+### Runtime Development
+
+Our nodes can be thought of as distributed state machines with shared resources.
+These resources are tied to knowing how busy our network is and contribute to increasing or decreasing transaction fees.
+Hence pallets must be developed with optimization in mind towards:
+
+- disk I/O
+- memory usage
+- computation
+
+#### Disk I/O
+
+Generally we aim to minimize the amount of storage a pallet uses _by storing consensus critical information only_.
+If we don't have logic to read a particular data, it probably means we don't need to store it on chain.
+
+Substrate is coupled with a variant of Merkle Patricia tree and key-value DB (e.g, [RocksDB][rust-rocksdb]), which means we don't have to optimize the underlying storage operations.
+
+We suggest the following to optimize storage items:
+
+- verify upfront and write last to ensure no partial data are persisted when an extrinsic fails
+- combine commonly accessed values together into a `struct`, rather than dispersing them across multiple storage items
+  - this will create fewer nodes in the underlying tree structure to keep `O(log N)` low
+  - we can update multiple values with a single `read` and `write`
+- use `xxHash` over `BLAKE2` hashing algorithm for its hashing speed
+  - NOTE: users won't be allowed to modify key prefixes so it's safe to use it
+- for storing lists, consider using `frame_support::BoundedVec` to ensure we don't run into iterating over a massive list
+- for storing large data, consider storing hash pointer or CID to [IPFS][ipfs]
+
+See [Storage][substrate-docs-storage] for more info.
+
+#### Memory Usage
+
+Related to [Disk I/O](#disk-io), we should consider using the smallest data types required for the job.
+
+#### Computation
+
+See [microbenchmarks](../testing/performance.md#microbenchmarks) for measuring a piece of code.
+
+#### Further Considerations
+
+- [Benchmarking best practices][substrate-docs-benchmarking]
+- [Parachain DevOps best practices][parachain-devops-best-practices]

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -27,6 +27,7 @@ As a team, we do not enforce a password schema, but passwords should be as secur
 - different from other passwords
 - safe from external viewing
 - no obvious personal information like your name
+- never share passwords via Slack or Email
 
 ## Data
 

--- a/index.md
+++ b/index.md
@@ -12,8 +12,9 @@ Follow relevant guidelines below to get started with Ajuna Network.
   - [Prerequisite](/docs/development/prerequisite.md)
   - [General](/docs/development/general.md)
   - [Rust](/docs/development/rust.md)
+  - [Substrate](/docs/development/substrate.md)
   - [Testing](/docs/testing/testing.md)
-  - [Performance testing](/docs/testing/performance.md)  
+  - [Performance testing](/docs/testing/performance.md)
   - [Tools and Extensions](/docs/development/tools-and-extensions.md)
-- Security  
+- Security
   - [Security](/docs/security/security.md)


### PR DESCRIPTION
Adding guidelines for Substrate development as part of [PLAT-9](https://ajunanetwork.atlassian.net/browse/PLAT-9).

Changes:
- remove `.vscode`
  - wasn't sure whether we need it source controlled
- add naming convention to `rust.md`
- add `substrate.md`
